### PR TITLE
turn this into a cargo generate compatible template repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,10 @@ Move into the cloudflare directory and run 'wrangler dev' to launch the worker l
 cd cloudflare
 wrangler dev
 ```
+
+If this fails with `[mf:err] Unhandled Promise Rejection: Error: To use the new ReadableStream() constructor, enable the streams_enable_constructors feature flag.` 
+then run this instead:
+```sh
+cd cloudflare
+wrangler dev --compatibility-flag streams_enable_constructors
+```

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,16 @@
+[template]
+# without this, the {{ hydrate }} string gets replaced with an empty string.
+# There may be a better way to do this, but this does work. Once there is a
+# real use for templating in this file, another solution may be
+# something like
+# let hydrate = "{ hydrate }";
+# format!("/* */ {hydrate}")
+# suggested from gbj.
+exclude = ["cloudflare/src/lib.rs"]
+
+ignore = [ 
+    "Cargo.lock",
+    "target",
+    "cloudflare/build",
+    "client/pkg"
+]


### PR DESCRIPTION
Adding `cargo-generate.toml` to turn this into a template repo compatible with cargo generate and fix a minor template replacement issue with `{{ hydrate }}`. This string isn't meant to be replaced, but cargo generate is, and using an empty string as the value.

Also updated the README.md file to help others just in case they run into the miniflare streaming issue I ran into.